### PR TITLE
Update dockerfile to node 11 and alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9
+FROM node:11-alpine
 
 LABEL name "lolisafe"
 LABEL version "3.0.0"
@@ -8,11 +8,10 @@ WORKDIR /usr/src/lolisafe
 
 COPY package.json yarn.lock ./
 
-RUN sh -c 'echo "deb http://www.deb-multimedia.org jessie main" >> /etc/apt/sources.list' \
-&& apt-key adv --keyserver keyring.debian.org --recv-keys 5C808C2B65558117 \
-&& apt-get update \
-&& apt-get install -y ffmpeg graphicsmagick \
-&& yarn install
+RUN apk add --no-cache --virtual build-dependencies python make g++ \
+&& apk add --no-cache ffmpeg \
+&& yarn install \
+&& apk del build-dependencies
 
 COPY . .
 


### PR DESCRIPTION
The old Dockerfile was broken and bloated.
I switched it to alpine linux since the debian graphicsmagicks dependency is no longer required.
I also pinned it to node 11 because one of the dependencies failed to build on node 12.