### PR TITLE
Remove duplicate proxy_redirect directive

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -60,7 +60,6 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        proxy_redirect off;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
The config check run by nginx will fail because this directive is stated twice