### PR TITLE
Add letsencrypt support instructions for nginx

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -64,3 +64,13 @@ server {
     }
 }
 ```
+### Certbot/Letsencrypt
+
+Include the following under the second `server` block:
+
+```    root /var/www/chibisafe;
+
+    location /.well-known/ {
+        try_files $uri $uri/ =404;
+    }
+```


### PR DESCRIPTION
`HTTP-01` verification for letsencrypt requires the creation of a folder and access to files therein, which now appear to be proxied and are thus not reachable. This remedies that.