### PR TITLE
fix: Disable max upload size when 0 and less

### DIFF
--- a/src/api/routes/uploads/uploadPOST.js
+++ b/src/api/routes/uploads/uploadPOST.js
@@ -72,7 +72,7 @@ const initChunks = async uuid => {
 const executeMulter = multer({
 	// Guide: https://github.com/expressjs/multer#limits
 	limits: {
-		fileSize: Util.config.maxSize * (1000 * 1000),
+		fileSize: Util.config.maxSize > 0 ? Util.config.maxSize * (1000 * 1000) : Number.MAX_VALUE,
 		// Maximum number of non-file fields.
 		// Dropzone.js will add 6 extra fields for chunked uploads.
 		// We don't use them for anything else.

--- a/src/site/components/uploader/Uploader.vue
+++ b/src/site/components/uploader/Uploader.vue
@@ -124,7 +124,7 @@ export default {
 			parallelChunkUploads: false,
 			chunkSize: this.config.chunkSize * 1000000,
 			chunksUploaded: this.dropzoneChunksUploaded,
-			maxFilesize: this.config.maxUploadSize,
+			maxFilesize: this.config.maxUploadSize > 0 ? this.config.maxUploadSize : Number.MAX_VALUE,
 			previewTemplate: this.$refs.template.innerHTML,
 			dictDefaultMessage: 'Drag & Drop your files or click to browse',
 			headers: { Accept: 'application/vnd.chibisafe.json' }


### PR DESCRIPTION
What fix? Drop zone didn't allow to upload files when max file size is disabled (set to 0 in settings), because any file size has higher size than this "limit"
This fix works, but I'm not a Javascript coder and idk if it's bad fix.

Edit: also API couldn't accept files too