### PR TITLE
Update sharp package to fix crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12805,17 +12805,33 @@
 			"integrity": "sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q=="
 		},
 		"node-abi": {
-			"version": "2.19.3",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-			"integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.5.0.tgz",
+			"integrity": "sha512-LtHvNIBgOy5mO8mPEUtkCW/YCRWYEKshIvqhe1GHHyXEHEB5mgICyYnAcl4qan3uFeRROErKGzatFHPf6kDxWw==",
 			"requires": {
-				"semver": "^5.4.1"
+				"semver": "^7.3.5"
 			},
 			"dependencies": {
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -13224,11 +13240,6 @@
 					"dev": true
 				}
 			}
-		},
-		"noop-logger": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "4.0.3",
@@ -15100,9 +15111,9 @@
 			}
 		},
 		"prebuild-install": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-			"integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
+			"integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -15110,40 +15121,13 @@
 				"minimist": "^1.2.3",
 				"mkdirp-classic": "^0.5.3",
 				"napi-build-utils": "^1.0.1",
-				"node-abi": "^2.7.0",
-				"noop-logger": "^0.1.1",
+				"node-abi": "^3.3.0",
 				"npmlog": "^4.0.1",
 				"pump": "^3.0.0",
 				"rc": "^1.2.7",
-				"simple-get": "^3.0.3",
+				"simple-get": "^4.0.0",
 				"tar-fs": "^2.0.0",
-				"tunnel-agent": "^0.6.0",
-				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"decompress-response": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-					"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-					"requires": {
-						"mimic-response": "^2.0.0"
-					}
-				},
-				"mimic-response": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-					"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-				},
-				"simple-get": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-					"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-					"requires": {
-						"decompress-response": "^4.2.0",
-						"once": "^1.3.1",
-						"simple-concat": "^1.0.0"
-					}
-				}
+				"tunnel-agent": "^0.6.0"
 			}
 		},
 		"prelude-ls": {
@@ -16422,31 +16406,71 @@
 			}
 		},
 		"sharp": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.27.0.tgz",
-			"integrity": "sha512-II+YBCW3JuVWQZdpTEA2IBjJcYXPuoKo3AUqYuW+FK9Um93v2gPE2ihICCsN5nHTUoP8WCjqA83c096e8n//Rw==",
+			"version": "0.29.3",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.29.3.tgz",
+			"integrity": "sha512-fKWUuOw77E4nhpyzCCJR1ayrttHoFHBT2U/kR/qEMRhvPEcluG4BKj324+SCO1e84+knXHwhJ1HHJGnUt4ElGA==",
 			"requires": {
-				"array-flatten": "^3.0.0",
-				"color": "^3.1.3",
+				"color": "^4.0.1",
 				"detect-libc": "^1.0.3",
-				"node-addon-api": "^3.1.0",
-				"npmlog": "^4.1.2",
-				"prebuild-install": "^6.0.0",
-				"semver": "^7.3.4",
+				"node-addon-api": "^4.2.0",
+				"prebuild-install": "^7.0.0",
+				"semver": "^7.3.5",
 				"simple-get": "^4.0.0",
 				"tar-fs": "^2.1.1",
 				"tunnel-agent": "^0.6.0"
 			},
 			"dependencies": {
-				"array-flatten": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-					"integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+				"color": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
+					"integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+					"requires": {
+						"color-convert": "^2.0.1",
+						"color-string": "^1.6.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-string": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+					"integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+					"requires": {
+						"color-name": "^1.0.0",
+						"simple-swizzle": "^0.2.2"
+					}
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
 				},
 				"node-addon-api": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
-					"integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
+					"integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 				}
 			}
 		},
@@ -18844,11 +18868,6 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
-		},
-		"which-pm-runs": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
 		},
 		"wide-align": {
 			"version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"rotating-file-stream": "^2.1.3",
 		"search-query-parser": "^1.5.5",
 		"serve-static": "^1.13.2",
-		"sharp": "^0.27.0",
+		"sharp": "^0.29.0",
 		"sqlite3": "^5.0.0",
 		"systeminformation": "^4.34.5",
 		"uuid": "^3.3.2",


### PR DESCRIPTION
In my installation, Chibisafe is crashing when generating image thumbnails. I was not able to determine exactly why because Node simply crashed with an `ELIFECYCLE` and no other helful logs. Through troubleshooting I narrowed it down to the call to `sharp` when generating a square thumbnail in `ThumbUtil.generateThumbnailForImage`.

After upgrading the sharp package to 0.29.x (0.29.3 currently), the problem was resolved.