### PR TITLE
feature/hyper-express <- basic upload api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"fluent-ffmpeg": "^2.1.2",
 				"fs-jetpack": "^4.3.1",
 				"helmet": "^5.1.0",
-				"hyper-express": "^6.4.8",
+				"hyper-express": "^6.4.9",
 				"jsonwebtoken": "^8.5.1",
 				"moment": "^2.29.4",
 				"pino": "^8.5.0",
@@ -2178,9 +2178,9 @@
 			}
 		},
 		"node_modules/hyper-express": {
-			"version": "6.4.8",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.8.tgz",
-			"integrity": "sha512-DRqXDzMnfSYrJznACtw/k+G360W0jxbCnyUV70L8bYO7+cl3NNApfJRfAKo0cCiKO1WDCK2ao3TUQxbMje6u2Q==",
+			"version": "6.4.9",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.9.tgz",
+			"integrity": "sha512-/kP9HiaHYw9bqSd+jTxL0aUu84PF7vbyc0psOP6l0bTkcf3Qu8GdlZt8bPcnd3wec67M/O/GxDkixkwfje9SkQ==",
 			"dependencies": {
 				"@types/busboy": "^0.3.1",
 				"@types/express": "^4.17.13",
@@ -5780,9 +5780,9 @@
 			}
 		},
 		"hyper-express": {
-			"version": "6.4.8",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.8.tgz",
-			"integrity": "sha512-DRqXDzMnfSYrJznACtw/k+G360W0jxbCnyUV70L8bYO7+cl3NNApfJRfAKo0cCiKO1WDCK2ao3TUQxbMje6u2Q==",
+			"version": "6.4.9",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.9.tgz",
+			"integrity": "sha512-/kP9HiaHYw9bqSd+jTxL0aUu84PF7vbyc0psOP6l0bTkcf3Qu8GdlZt8bPcnd3wec67M/O/GxDkixkwfje9SkQ==",
 			"requires": {
 				"@types/busboy": "^0.3.1",
 				"@types/express": "^4.17.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,14 @@
 				"@types/bcryptjs": "^2.4.2",
 				"adm-zip": "^0.5.9",
 				"bcryptjs": "^2.4.3",
+				"blake3": "^2.1.7",
 				"cors": "^2.8.5",
 				"dotenv": "^16.0.1",
 				"ffmpeg-probe": "^1.0.6",
 				"fluent-ffmpeg": "^2.1.2",
 				"fs-jetpack": "^4.3.1",
 				"helmet": "^5.1.0",
-				"hyper-express": "^6.4.9",
+				"hyper-express": "^6.4.2",
 				"jsonwebtoken": "^8.5.1",
 				"moment": "^2.29.4",
 				"pino": "^8.5.0",
@@ -247,9 +248,9 @@
 			}
 		},
 		"node_modules/@types/busboy": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.2.tgz",
-			"integrity": "sha512-iEvdm9Z9KdSs/ozuh1Z7ZsXrOl8F4M/CLMXPZHr3QuJ4d6Bjn+HBMC5EMKpwpAo8oi8iK9GZfFoHaIMrrZgwVw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.0.tgz",
+			"integrity": "sha512-ncOOhwmyFDW76c/Tuvv9MA9VGYUCn8blzyWmzYELcNGDb0WXWLSmFi7hJq25YdRBYJrmMBB5jZZwUjlJe9HCjQ==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -806,6 +807,12 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/blake3": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
+			"integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==",
+			"hasInstallScript": true
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -870,7 +877,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -1905,8 +1911,7 @@
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"node_modules/function.prototype.name": {
 			"version": "1.1.5",
@@ -1945,7 +1950,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
 			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -2054,7 +2058,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"dependencies": {
 				"function-bind": "^1.1.1"
 			},
@@ -2096,7 +2099,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
 			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -2178,9 +2180,9 @@
 			}
 		},
 		"node_modules/hyper-express": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.9.tgz",
-			"integrity": "sha512-/kP9HiaHYw9bqSd+jTxL0aUu84PF7vbyc0psOP6l0bTkcf3Qu8GdlZt8bPcnd3wec67M/O/GxDkixkwfje9SkQ==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.2.tgz",
+			"integrity": "sha512-R4cvUrdDYpulzer6GShRVZQs6V69HRwkV28Y+e3YnSMh2nYf0ipvCmCbOOKbcecUs64cNbY49hujht/njYAgLw==",
 			"dependencies": {
 				"@types/busboy": "^0.3.1",
 				"@types/express": "^4.17.13",
@@ -2190,6 +2192,7 @@
 				"cookie": "^0.4.1",
 				"cookie-signature": "^1.1.0",
 				"mime-types": "^2.1.33",
+				"qs": "^6.10.3",
 				"range-parser": "^1.2.1",
 				"type-is": "^1.6.18",
 				"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.10.0"
@@ -2950,7 +2953,6 @@
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
 			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -3325,6 +3327,20 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"dependencies": {
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3630,7 +3646,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-			"dev": true,
 			"dependencies": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",
@@ -4337,9 +4352,9 @@
 			}
 		},
 		"@types/busboy": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.3.2.tgz",
-			"integrity": "sha512-iEvdm9Z9KdSs/ozuh1Z7ZsXrOl8F4M/CLMXPZHr3QuJ4d6Bjn+HBMC5EMKpwpAo8oi8iK9GZfFoHaIMrrZgwVw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.0.tgz",
+			"integrity": "sha512-ncOOhwmyFDW76c/Tuvv9MA9VGYUCn8blzyWmzYELcNGDb0WXWLSmFi7hJq25YdRBYJrmMBB5jZZwUjlJe9HCjQ==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -4733,6 +4748,11 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"blake3": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
+			"integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4777,7 +4797,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
 			"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"get-intrinsic": "^1.0.2"
@@ -5583,8 +5602,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
 			"version": "1.1.5",
@@ -5614,7 +5632,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
 			"integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
@@ -5690,7 +5707,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -5719,8 +5735,7 @@
 		"has-symbols": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-			"dev": true
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
@@ -5780,11 +5795,11 @@
 			}
 		},
 		"hyper-express": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.9.tgz",
-			"integrity": "sha512-/kP9HiaHYw9bqSd+jTxL0aUu84PF7vbyc0psOP6l0bTkcf3Qu8GdlZt8bPcnd3wec67M/O/GxDkixkwfje9SkQ==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/hyper-express/-/hyper-express-6.4.2.tgz",
+			"integrity": "sha512-R4cvUrdDYpulzer6GShRVZQs6V69HRwkV28Y+e3YnSMh2nYf0ipvCmCbOOKbcecUs64cNbY49hujht/njYAgLw==",
 			"requires": {
-				"@types/busboy": "^0.3.1",
+				"@types/busboy": "^1.5.0",
 				"@types/express": "^4.17.13",
 				"@types/node": "^16.11.6",
 				"accepts": "^1.3.7",
@@ -5792,6 +5807,7 @@
 				"cookie": "^0.4.1",
 				"cookie-signature": "^1.1.0",
 				"mime-types": "^2.1.33",
+				"qs": "^6.10.3",
 				"range-parser": "^1.2.1",
 				"type-is": "^1.6.18",
 				"uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.10.0"
@@ -6359,8 +6375,7 @@
 		"object-inspect": {
 			"version": "1.12.2",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
-			"dev": true
+			"integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
@@ -6641,6 +6656,14 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"qs": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"requires": {
+				"side-channel": "^1.0.4"
+			}
+		},
 		"queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6829,7 +6852,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
 			"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.0",
 				"get-intrinsic": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"fluent-ffmpeg": "^2.1.2",
 		"fs-jetpack": "^4.3.1",
 		"helmet": "^5.1.0",
-		"hyper-express": "^6.4.8",
+		"hyper-express": "^6.4.9",
 		"jsonwebtoken": "^8.5.1",
 		"moment": "^2.29.4",
 		"pino": "^8.5.0",

--- a/package.json
+++ b/package.json
@@ -77,18 +77,24 @@
 		"@types/bcryptjs": "^2.4.2",
 		"adm-zip": "^0.5.9",
 		"bcryptjs": "^2.4.3",
+		"blake3": "^2.1.7",
 		"cors": "^2.8.5",
 		"dotenv": "^16.0.1",
 		"ffmpeg-probe": "^1.0.6",
 		"fluent-ffmpeg": "^2.1.2",
 		"fs-jetpack": "^4.3.1",
 		"helmet": "^5.1.0",
-		"hyper-express": "^6.4.9",
+		"hyper-express": "^6.4.2",
 		"jsonwebtoken": "^8.5.1",
 		"moment": "^2.29.4",
 		"pino": "^8.5.0",
 		"randomstring": "^1.2.2",
 		"sharp": "^0.30.7",
 		"uuid": "^8.3.2"
+	},
+	"overrides": {
+		"hyper-express": {
+			"@types/busboy": "^1.5.0"
+		}
 	}
 }

--- a/src/api/main.ts
+++ b/src/api/main.ts
@@ -16,8 +16,8 @@ process.on('unhandledRejection', error => {
 
 const start = async () => {
 	const server = new HyperExpress.Server({
-		trust_proxy: true,
-		fast_buffers: true
+		// trust_proxy: true,
+		// fast_buffers: true
 	});
 
 	// TODO: Figure this out

--- a/src/api/middlewares/authOptional.ts
+++ b/src/api/middlewares/authOptional.ts
@@ -1,0 +1,41 @@
+// TODO: Merge with auth middleware,
+// but have it be possible to actually make auth optional (?)
+
+import type { Response, MiddlewareNext } from 'hyper-express';
+import type { RequestWithOptionalUser } from '../structures/interfaces';
+import JWT from 'jsonwebtoken';
+import prisma from '../structures/database';
+
+interface Decoded {
+	sub: number;
+}
+
+export default (req: RequestWithOptionalUser, res: Response, next: MiddlewareNext) => {
+	if (!req.headers.authorization) return next();
+
+	const token = req.headers.authorization.split(' ')[1];
+	if (!token) return next();
+
+	// eslint-disable-next-line @typescript-eslint/no-misused-promises
+	JWT.verify(token, process.env.JWT_SECRET ?? '', async (error, decoded) => {
+		if (error) return res.status(401).json({ message: 'Invalid token' });
+		const id = (decoded as Decoded | undefined)?.sub ?? null;
+		if (!id) return res.status(401).json({ message: 'Invalid authorization' });
+
+		const user = await prisma.users.findFirst({
+			where: {
+				id
+			},
+			select: {
+				id: true,
+				uuid: true,
+				username: true,
+				isAdmin: true
+			}
+		});
+
+		if (!user) return res.status(401).json({ message: "User doesn't exist" });
+		req.user = user;
+		next();
+	});
+};

--- a/src/api/middlewares/log.ts
+++ b/src/api/middlewares/log.ts
@@ -1,4 +1,4 @@
-import type { Request } from 'hyper-express';
+import type { MiddlewareNext, Request } from 'hyper-express';
 import log from '../utils/Log';
 
 interface DebugInformation {
@@ -10,17 +10,20 @@ interface DebugInformation {
 	query: object | undefined;
 }
 
-export default async (req: Request) => {
+export default (req: Request, res: Response, next: MiddlewareNext) => {
 	const debug = {
 		ip: req.ip,
 		url: req.url,
 		method: req.method
 	} as DebugInformation;
 
-	const body = await req.json();
-	if (body) debug.body = body;
+	// TODO: Do not use Request.json() except on routes that exclusively accept JSON payload
+	// const body = await req.json();
+	// if (body) debug.body = body;
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 	if (req.path_parameters) debug.params = req.path_parameters;
 
 	log.debug(JSON.stringify(debug));
+
+	return next();
 };

--- a/src/api/routes/files/Upload.ts
+++ b/src/api/routes/files/Upload.ts
@@ -1,0 +1,254 @@
+// NOTE: Should this file be named as such?
+
+import type { MultipartField, Response } from 'hyper-express';
+
+import * as blake3 from 'blake3';
+import jetpack from 'fs-jetpack';
+import path from 'path';
+import { inspect } from 'util';
+
+import {
+	constructFilePublicLink,
+	deleteFile,
+	getExtension,
+	getUniqueFileIdentifier,
+	storeFileToDb,
+	unholdFileIdentifiers,
+	uploadPath
+} from '../../utils/File';
+import log from '../../utils/Log';
+import { getEnvironmentDefaults, getHost } from '../../utils/Util';
+
+import type { WriteStream } from 'fs';
+import type { NodeHash, NodeHashReader } from 'blake3';
+import type { RequestWithOptionalUser, FileBasic } from '../../structures/interfaces';
+
+interface UploadResult {
+	message: string;
+	name?: string;
+	hash?: string;
+	size?: number;
+	url?: string;
+	thumb?: string;
+	deleteUrl?: string;
+	repeated?: boolean;
+}
+
+export const options = {
+	url: '/upload',
+	method: 'post',
+	middlewares: ['authOptional'],
+	options: {
+		max_body_length: getEnvironmentDefaults().maxSize * 1e6 // in bytes
+	}
+};
+
+export const run = async (req: RequestWithOptionalUser, res: Response) => {
+	// TODO: Perhaps have Request Content-Type be configurable via route options,
+	// then have it be enforced via a middleware?
+	if (!req.is('multipart/form-data')) {
+		return res.status(400).json({ message: 'Content-Type must be multipart/form-data.' });
+	}
+
+	log.debug(inspect(req.user?.username));
+
+	// Init empty Request.body and Request.files
+	const body: { [index: string]: any } = {};
+	const files: FileBasic[] = [];
+
+	const cleanUpFiles = async () => {
+		unholdFileIdentifiers(res);
+		return Promise.all(
+			files.map(async file => {
+				if (!file.name) return;
+				return deleteFile(file.name);
+			})
+		);
+	};
+
+	// TODO: Chunked uploads.
+	const multipart = await req
+		.multipart(
+			{
+				// https://github.com/mscdex/busboy/tree/v1.6.0#exports
+				// This would otherwise defaults to latin1
+				defParamCharset: 'utf8',
+				limits: {
+					fileSize: getEnvironmentDefaults().maxSize * 1e6, // in bytes
+					// Maximum number of non-file fields.
+					fields: 1,
+					// Maximum number of file fields.
+					files: 1
+				}
+			},
+			async (field: MultipartField) => {
+				/*
+					Keep non-files fields in Request.body.
+					Since fields get processed in sequence, depending on the order at which they were defined,
+					chunked uploads data must be set before the files[] field which contain the actual file.
+				*/
+				if (field.truncated) {
+					// Re-map Dropzone chunked uploads keys so people can manually use the API without prepending 'dz'
+					let name = field.name;
+					if (name.startsWith('dz')) {
+						name = name.replace(/^dz/, '');
+					}
+
+					body[name] = field.value;
+					return;
+				}
+
+				// Process files immediately and push into Request.files array
+				if (field.file) {
+					if (field.name !== 'files[]') {
+						throw new Error(`Unexpected file-type field: ${field.name}`);
+					}
+
+					// Push immediately as we will only be adding props into the file object down the line
+					const file: FileBasic = {
+						name: '',
+						identifier: '',
+						extension: '',
+						original: field.file.name ?? '',
+						type: field.mime_type,
+						size: 0,
+						hash: '',
+						ip: req.ip
+					};
+					files.push(file);
+
+					file.extension = getExtension(file.original);
+					// TODO: Check if extension is blocked
+
+					file.identifier = await getUniqueFileIdentifier();
+					if (!file.identifier) {
+						throw new Error('Couldnt allocate identifier for file');
+					}
+
+					file.name = `${file.identifier}${file.extension}`;
+
+					const readStream = field.file.stream;
+					let writeStream: WriteStream | undefined;
+					let hashStream: NodeHash<NodeHashReader> | undefined;
+
+					// Write the file into disk, and supply required props into file object
+					await new Promise<void>((resolve, reject) => {
+						// Ensure this Promise's status can be asserted later
+						const _resolve = () => {
+							file.promised = true;
+							return resolve();
+						};
+
+						readStream.once('error', reject);
+
+						writeStream = jetpack.createWriteStream(path.join(uploadPath, file.name));
+						hashStream = blake3.createHash();
+
+						// Re-init stream errors listeners for this Request
+						writeStream.once('error', reject);
+						hashStream.once('error', reject);
+
+						readStream.pause();
+						readStream.on('data', data => {
+							log.debug('readStream:data');
+							// .dispose() will destroy this internal component,
+							// so use it as an indicator of whether the hashStream has been .dispose()'d
+							// @ts-ignore
+							if (hashStream?.hash?.hash) {
+								hashStream.update(data);
+							}
+						});
+
+						// We immediately listen for writeStream's finish event
+						writeStream.once('finish', () => {
+							log.debug('writeStream:finish');
+							if (writeStream?.bytesWritten) {
+								file.size = writeStream.bytesWritten;
+							}
+							// @ts-ignore
+							if (hashStream?.hash?.hash) {
+								const hash = hashStream.digest('hex');
+								file.hash = file.size === 0 ? '' : hash;
+							}
+							return _resolve();
+						});
+
+						// Pipe readStream to writeStream
+						log.debug('readStream.pipe(writeStream)');
+						readStream.pipe(writeStream);
+					}).catch(error => {
+						// Dispose of unfinished write & hasher streams
+						if (writeStream && !writeStream.destroyed) {
+							writeStream.destroy();
+						}
+						// @ts-ignore
+						if (hashStream?.hash?.hash) {
+							hashStream.dispose();
+						}
+
+						// Re-throw error
+						throw error;
+					});
+
+					if (file.size === 0) {
+						throw new Error('Zero-bytes files are not allowed');
+					}
+				}
+			}
+		)
+		.then(() => true)
+		.catch(error => {
+			// Clean up temp files (do not wait)
+			void cleanUpFiles();
+
+			// Response.multipart() itself may throw string errors
+			let errorString;
+			if (typeof error !== 'string') {
+				errorString = error.toString();
+			}
+			res.status(400).json({ message: errorString });
+			log.debug(errorString);
+			return false;
+		});
+
+	log.debug(`req.multipart(): ${inspect(multipart)}`);
+	if (!multipart) return res.end();
+
+	log.debug(inspect(files));
+	if (!files.length) {
+		return res.status(400).json({ message: 'No files' });
+	}
+
+	if (files.length > 1) {
+		return res.status(400).json({ message: 'Can only upload one file at a time' });
+	}
+
+	// If for some reason Request.multipart() resolves before a file's Promise.
+	// Typically caused by something hanging up longer than
+	// uWebSockets.js' internal security timeout (10 seconds).
+	if (files.some(file => !file.promised)) {
+		// Clean up temp (do not wait)
+		void cleanUpFiles();
+		return;
+	}
+
+	const stored = await storeFileToDb(req.user, files[0]);
+	// TODO
+	// @ts-ignore
+	const file = constructFilePublicLink(req, stored.file);
+
+	const result: UploadResult = {
+		message: 'Successfully uploaded the file.',
+		name: file.name,
+		hash: file.hash,
+		size: file.size,
+		url: file.url,
+		thumb: file.thumb,
+		deleteUrl: `${getHost(req)}/api/file/${file.id}`
+	};
+	if (stored.repeated) {
+		result.repeated = true;
+	}
+
+	return res.json(result);
+};

--- a/src/api/structures/interfaces.ts
+++ b/src/api/structures/interfaces.ts
@@ -1,13 +1,20 @@
 import type { Request } from 'hyper-express';
 
+export interface RequestUser {
+	id: number;
+	uuid: string;
+	username: string;
+	isAdmin: boolean;
+	apiKey?: string | null | undefined;
+}
+
 export interface RequestWithUser extends Request {
-	user: {
-		id: number;
-		uuid: string;
-		username: string;
-		isAdmin: boolean;
-		apiKey?: string | null | undefined;
-	};
+	user: RequestUser;
+}
+
+// TODO
+export interface RequestWithOptionalUser extends Request {
+	user?: RequestUser;
 }
 
 export interface User {
@@ -22,6 +29,18 @@ export interface User {
 	apiKeyEditedAt: string;
 	createdAt: string;
 	editedAt: string;
+}
+
+export interface FileBasic {
+	name: string;
+	identifier: string | null;
+	extension: string;
+	original: string;
+	type: string;
+	size: number;
+	hash: string;
+	ip: string;
+	promised?: boolean;
 }
 
 export interface File {
@@ -96,5 +115,6 @@ export interface Settings {
 export interface RouteOptions {
 	url: string;
 	method: string;
+	options?: any;
 	middlewares?: string[];
 }

--- a/src/api/structures/routes.ts
+++ b/src/api/structures/routes.ts
@@ -1,5 +1,6 @@
 import jetpack from 'fs-jetpack';
 import path from 'path';
+import { inspect } from 'util';
 import type { Server, Request, Response } from 'hyper-express';
 import type { RouteOptions } from './interfaces';
 import log from '../utils/Log';
@@ -29,6 +30,10 @@ export default {
 
 				options.url = `${route.options?.ignoreRoutePrefix ? '' : '/api'}${options.url}`;
 
+				if (!options.options) {
+					options.options = {};
+				}
+
 				// Run middlewares if any, and in order of execution
 				const middlewares: any[] = [];
 
@@ -46,14 +51,17 @@ export default {
 					}
 				}
 
+				options.options.middlewares = middlewares;
+
+				// TODO
+				if (options.url === '/api/upload') {
+					log.debug(inspect(options));
+				}
+
 				// Register the route in hyper-express
 				// @ts-ignore
-				server[options.method](
-					options.url,
-					{
-						middlewares
-					},
-					(req: Request, res: Response) => route.run(req, res)
+				server[options.method](options.url, options.options, (req: Request, res: Response) =>
+					route.run(req, res)
 				);
 
 				log.info(`Found route |${addSpaces(options.method.toUpperCase())} ${options.url}`);

--- a/src/api/utils/File.ts
+++ b/src/api/utils/File.ts
@@ -234,32 +234,33 @@ export const saveFileToAlbum = async (albumId: number, insertedId: number) => {
 	}
 };
 
-export const getExtension = (filename: string) => {
+export const getExtension = (filename: string, lower = false): string => {
 	// Always return blank string if the filename does not seem to have a valid extension
 	// Files such as .DS_Store (anything that starts with a dot, without any extension after) will still be accepted
 	if (!/\../.test(filename)) return '';
 
-	let lower = filename.toLowerCase(); // due to this, the returned extname will always be lower case
 	let multi = '';
-	let extname = '';
+	let extension = '';
 
 	// check for multi-archive extensions (.001, .002, and so on)
-	if (/\.\d{3}$/.test(lower)) {
-		multi = lower.slice(lower.lastIndexOf('.') - lower.length);
-		lower = lower.slice(0, lower.lastIndexOf('.'));
+	if (/\.\d{3}$/.test(filename)) {
+		multi = filename.slice(filename.lastIndexOf('.') - filename.length);
+		filename = filename.slice(0, filename.lastIndexOf('.'));
 	}
 
 	// check against extensions that must be preserved
 	for (const extPreserve of preserveExtensions) {
-		if (lower.endsWith(extPreserve)) {
-			extname = extPreserve;
+		const match = filename.match(extPreserve);
+		if (match?.[0]) {
+			extension = match[0];
 			break;
 		}
 	}
 
-	if (!extname) {
-		extname = lower.slice(lower.lastIndexOf('.') - lower.length); // path.extname(lower)
+	if (!extension) {
+		extension = filename.slice(filename.lastIndexOf('.') - filename.length); // path.extname(filename)
 	}
 
-	return extname + multi;
+	const str = extension + multi;
+	return lower ? str.toLowerCase() : str;
 };

--- a/src/api/utils/File.ts
+++ b/src/api/utils/File.ts
@@ -13,7 +13,9 @@ import { getHost, getConfig } from './Util';
 import type { File, ExtendedFile, ExtendedFileWithData, Album, User } from '../structures/interfaces';
 import type { Request, Response } from 'hyper-express';
 
-const preserveExtensions = ['.tar.gz', '.tar.z', '.tar.bz2', '.tar.lzma', '.tar.lzo', '.tar.xz'];
+const preserveExtensions = [
+	/\.tar\.\w+/i // tarballs
+];
 export const uploadPath = path.join(__dirname, '../../../', 'uploads');
 
 export const isExtensionBlocked = async (extension: string) =>

--- a/src/api/utils/Util.ts
+++ b/src/api/utils/Util.ts
@@ -36,8 +36,9 @@ export const getEnvironmentDefaults = () =>
 		rateLimitMax: process.env.RATE_LIMIT_MAX ?? 5,
 		secret: process.env.SECRET ?? randomstring.generate(64),
 		serviceName: process.env.SERVICE_NAME ?? 'change-me',
-		chunkSize: process.env.CHUNK_SIZE ?? 90,
-		maxSize: process.env.MAX_SIZE ?? 5000,
+		// TODO: Pretty sure all env variables will always be string if fetched as-is from process.env
+		chunkSize: process.env.CHUNK_SIZE ? parseInt(process.env.CHUNK_SIZE, 10) : 90,
+		maxSize: process.env.MAX_SIZE ? parseInt(process.env.MAX_SIZE, 10) : 5000,
 		// eslint-disable-next-line eqeqeq
 		generateZips: process.env.GENERATE_ZIPS == undefined ? true : false,
 		generatedFilenameLength: process.env.GENERATED_FILENAME_LENGTH ?? 12,


### PR DESCRIPTION
This can already accept and store generic file uploads via `/api/upload` (no chunked uploads), however there are quite a few things to note:
- Typings
  I added/changed a few type definitions, but I mostly didn't have any clear directions of how to go at it, so take them as mere temporary stopgap changes so that I could proceed with other sections of the codes
- **Need an alternative auth middleware where auth can be optional**
  Specifically for upload API, unless the installation is configured to private, it's supposed to be able to accept non-auth'd uploads too
  I copied-pasted the original auth middleware, and added slight changes to only accept auth optionally, as a quick stopgap measure
  But repeat codes, bad
- **Temporarily downgraded to Hyper-Express 6.4.2**
  For reasons unknown, when 6.4.4~6.4.9 (latest) is used in this project, the same backpressure mishandling that causes upload streams to hang is almost always reproducible in this project for 100kB+ files
Relevant discussion: https://github.com/kartikk221/hyper-express/discussions/103
  In my project, I can confirm that it's supposed to be already fixed since 6.4.7, but alas..
  I have no idea where to even begin to debug this

I'll have to stop here for now, because the last point is a very big blocker